### PR TITLE
Add vehicle_data call

### DIFF
--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -14,6 +14,9 @@ class Vehicle:
     def is_mobile_access_enabled(self):
         return self._api_client.get('vehicles/{}/mobile_enabled'.format(self.id))
 
+    def get_data(self):
+        return self._api_client.get('vehicles/{}/vehicle_data'.format(self.id))
+
     def get_state(self):
         return self._api_client.get('vehicles/{}/data_request/vehicle_state'.format(self.id))
 


### PR DESCRIPTION
This PR adds the `vehicle_data` call which contains the vehicle configuration (which with the current calls cannot be requested). It e.g. contains the `online`/`offline` state of the Tesla, useful in case you want to check if a wake up is necessary.

More information about the call can be found here: https://tesla-api.timdorr.com/vehicle/state/data