### PR TITLE
Restore from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,47 @@ This is a package for connecting to the Tesla API.
 ## Usage for a vehicle
 
 ```python
+import asyncio
+from tesla_api import TeslaApiClientAsync
+
+async def main():
+    client = TeslaApiClientAsync('your@email.com', 'yourPassword')
+
+    vehicles = await client.list_vehicles()
+
+    for v in vehicles:
+        print(v.vin)
+        await v.controls.flash_lights()
+
+asyncio.run(main())
+```
+
+
+## Usage for Powerwall 2
+
+```python
+import asyncio
+from tesla_api import TeslaApiClientAsync
+
+async def main():
+    client = TeslaApiClientAsync('your@email.com', 'yourPassword')
+
+    energy_sites = await client.list_energy_sites()
+    print("Number of energy sites = %d" % (len(energy_sites)))
+    assert(len(energy_sites)==1)
+    reserve = await energy_sites[0].get_backup_reserve_percent()
+    print("Backup reserve percent = %d" % (reserve))
+    print("Increment backup reserve percent")
+    await energy_sites[0].set_backup_reserve_percent(reserve+1)
+
+asyncio.run(main())
+```
+
+## Synchronous interface
+
+There is also a legacy synchronous interface available if not using an asyncio loop in your project:
+
+```python
 from tesla_api import TeslaApiClient
 
 client = TeslaApiClient('your@email.com', 'yourPassword')
@@ -14,21 +55,4 @@ vehicles = client.list_vehicles()
 for v in vehicles:
     print(v.vin)
     v.controls.flash_lights()
-```
-
-
-## Usage for Powerwall 2
-
-```python
-from tesla_api import TeslaApiClient
-
-client = TeslaApiClient('your@email.com', 'yourPassword')
-
-energy_sites = client.list_energy_sites()
-print("Number of energy sites = %d" % (len(energy_sites)))
-assert(len(energy_sites)==1)
-reserve = energy_sites[0].get_backup_reserve_percent()
-print("Backup reserve percent = %d" % (reserve))
-print("Increment backup reserve percent")
-energy_sites[0].set_backup_reserve_percent(reserve+1)
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="tesla_api",
-    version="1.0.7",
+    version="1.0.8",
     author="M. Lowijs",
     author_email="mlowijs@gmail.com",
     description="API client for Tesla",

--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -14,10 +14,16 @@ OAUTH_CLIENT_ID = '81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796
 OAUTH_CLIENT_SECRET = 'c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3'
 
 class TeslaApiClientAsync:
-    def __init__(self, email, password):
+    def __init__(self, email=None, password=None, token=None):
+        """Creates client from provided credentials.
+
+        If token is not provided, or is no longer valid, then a new token will
+        be fetched if email and password are provided.
+        """
+        assert token is not None or (email is not None and password is not None)
         self._email = email
         self._password = password
-        self._token = None
+        self.token = token
         self._session = aiohttp.ClientSession()
 
     async def close(self):
@@ -55,18 +61,18 @@ class TeslaApiClientAsync:
         return response_json
 
     async def authenticate(self):
-        if not self._token:
-            self._token = await self._get_new_token()
+        if not self.token:
+            self.token = await self._get_new_token()
 
-        expiry_time = timedelta(seconds=self._token['expires_in'])
-        expiration_date = datetime.fromtimestamp(self._token['created_at']) + expiry_time
+        expiry_time = timedelta(seconds=self.token['expires_in'])
+        expiration_date = datetime.fromtimestamp(self.token['created_at']) + expiry_time
 
         if datetime.utcnow() >= expiration_date:
-            self._token = await self._refresh_token(self._token['refresh_token'])
+            self.token = await self._refresh_token(self.token['refresh_token'])
 
     def _get_headers(self):
         return {
-            'Authorization': 'Bearer {}'.format(self._token['access_token'])
+            'Authorization': 'Bearer {}'.format(self.token['access_token'])
         }
 
     async def get(self, endpoint):

--- a/tesla_api/charge.py
+++ b/tesla_api/charge.py
@@ -1,24 +1,39 @@
+import asyncio
+
 class Charge:
     def __init__(self, api_client, vehicle_id):
         self._api_client = api_client
         self._vehicle_id = vehicle_id
 
-    def get_state(self):
-        return self._api_client.get('vehicles/{}/data_request/charge_state'.format(self._vehicle_id))
+    async def get_state(self):
+        return await self._api_client.get('vehicles/{}/data_request/charge_state'.format(self._vehicle_id))
 
-    def start_charging(self):
-        return self._api_client.post('vehicles/{}/command/charge_start'.format(self._vehicle_id))
+    async def start_charging(self):
+        return await self._api_client.post('vehicles/{}/command/charge_start'.format(self._vehicle_id))
 
-    def stop_charging(self):
-        return self._api_client.post('vehicles/{}/command/charge_stop'.format(self._vehicle_id))
+    async def stop_charging(self):
+        return await self._api_client.post('vehicles/{}/command/charge_stop'.format(self._vehicle_id))
 
-    def set_charge_limit(self, percentage):
+    async def set_charge_limit(self, percentage):
         percentage = round(percentage)
 
-        if percentage < 50 or percentage > 100:
+        if not (50 <= percentage <= 100):
             raise ValueError('Percentage should be between 50 and 100')
 
-        return self._api_client.post(
+        return await self._api_client.post(
             'vehicles/{}/command/set_charge_limit'.format(self._vehicle_id),
             {'percent': percentage}
         )
+
+class ChargeSync(Charge):
+    def get_state(self):
+        return asyncio.get_event_loop().run_until_complete(super().get_state())
+
+    def start_charging(self):
+        return asyncio.get_event_loop().run_until_complete(super().start_charging())
+
+    def stop_charging(self):
+        return asyncio.get_event_loop().run_until_complete(super().stop_charging())
+
+    def set_charge_limit(self, percentage):
+        return asyncio.get_event_loop().run_until_complete(super().set_charge_limit(percentage))

--- a/tesla_api/climate.py
+++ b/tesla_api/climate.py
@@ -1,25 +1,27 @@
+import asyncio
+
 class Climate:
     def __init__(self, api_client, vehicle_id):
         self._api_client = api_client
         self._vehicle_id = vehicle_id
 
-    def get_state(self):
-        return self._api_client.get('vehicles/{}/data_request/climate_state'.format(self._vehicle_id))
+    async def get_state(self):
+        return await self._api_client.get('vehicles/{}/data_request/climate_state'.format(self._vehicle_id))
 
-    def start_climate(self):
-        return self._api_client.post('vehicles/{}/command/auto_conditioning_start'.format(self._vehicle_id))
+    async def start_climate(self):
+        return await self._api_client.post('vehicles/{}/command/auto_conditioning_start'.format(self._vehicle_id))
 
-    def stop_climate(self):
-        return self._api_client.post('vehicles/{}/command/auto_conditioning_stop'.format(self._vehicle_id))
+    async def stop_climate(self):
+        return await self._api_client.post('vehicles/{}/command/auto_conditioning_stop'.format(self._vehicle_id))
 
-    def set_temperature(self, driver_temperature, passenger_temperature = None):
-        return self._api_client.post(
+    async def set_temperature(self, driver_temperature, passenger_temperature=None):
+        return await self._api_client.post(
             'vehicles/{}/command/set_temps'.format(self._vehicle_id),
             {'driver_temp': driver_temperature,
              'passenger_temp': passenger_temperature or driver_temperature}
         )
     
-    def set_seat_heater(self,temp=0,seat=0):
+    async def set_seat_heater(self, temp=0, seat=0):
         # temp = The desired level for the heater. (0-3)
         # The desired seat to heat. (0-5)
         # 0 - Driver
@@ -27,11 +29,32 @@ class Climate:
         # 2 - Rear left
         # 4 - Rear center
         # 5 - Rear right
-        return self._api_client.post('vehicles/{}/command/remote_seat_heater_request'.format(self._vehicle_id),{'heater':seat,'level':temp})
+        return await self._api_client.post('vehicles/{}/command/remote_seat_heater_request'.format(self._vehicle_id),{'heater':seat,'level':temp})
+
+    async def start_steering_wheel_heater(self):
+        return await self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':True})
+
+    async def stop_steering_wheel_heater(self):
+        return await self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':False})
+
+class ClimateSync(Climate):
+    def get_state(self):
+        return asyncio.get_event_loop().run_until_complete(super().get_state())
+
+    def start_climate(self):
+        return asyncio.get_event_loop().run_until_complete(super().start_climate())
+
+    def stop_climate(self):
+        return asyncio.get_event_loop().run_until_complete(super().stop_climate())
+
+    def set_temperature(self, driver_temperature, passenger_temperature=None):
+        return asyncio.get_event_loop().run_until_complete(super().set_temperature(driver_temperature, passenger_temperature))
+
+    def set_seat_heater(self, temp=0, seat=0):
+        return asyncio.get_event_loop().run_until_complete(super().set_seat_heater(temp, seat))
 
     def start_steering_wheel_heater(self):
-        return self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':True})
+        return asyncio.get_event_loop().run_until_complete(super().start_steering_wheel_heater())
 
     def stop_steering_wheel_heater(self):
-        return self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':False})
-    
+        return asyncio.get_event_loop().run_until_complete(super().stop_steering_wheel_heater())

--- a/tesla_api/controls.py
+++ b/tesla_api/controls.py
@@ -1,3 +1,5 @@
+import asyncio
+
 STATE_VENT = 'vent'
 STATE_CLOSE = 'close'
 
@@ -6,23 +8,39 @@ class Controls:
         self._api_client = api_client
         self._vehicle_id = vehicle_id
 
-    def _set_sunroof_state(self, state):
-        return self._api_client.post(
+    async def _set_sunroof_state(self, state):
+        return await self._api_client.post(
             'vehicles/{}/command/sun_roof_control'.format(self._vehicle_id),
             {'state': state}
         )
 
+    async def vent_sunroof(self):
+        return await self._set_sunroof_state(STATE_VENT)
+
+    async def close_sunroof(self):
+        return await self._set_sunroof_state(STATE_CLOSE)
+
+    async def flash_lights(self):
+        return await self._api_client.post('vehicles/{}/command/flash_lights'.format(self._vehicle_id))
+
+    async def honk_horn(self):
+        return await self._api_client.post('vehicles/{}/command/honk_horn'.format(self._vehicle_id))
+
+    async def open_charge_port(self):
+        return await self._api_client.post('vehicles/{}/command/charge_port_door_open'.format(self._vehicle_id))
+
+class ControlsSync(Controls):
     def vent_sunroof(self):
-        return self._set_sunroof_state(STATE_VENT)
+        return asyncio.get_event_loop().run_until_complete(super().vent_sunroof())
         
     def close_sunroof(self):
-        return self._set_sunroof_state(STATE_CLOSE)
+        return asyncio.get_event_loop().run_until_complete(super().close_sunroof())
 
     def flash_lights(self):
-        return self._api_client.post('vehicles/{}/command/flash_lights'.format(self._vehicle_id))
+        return asyncio.get_event_loop().run_until_complete(super().flash_lights())
 
     def honk_horn(self):
-        return self._api_client.post('vehicles/{}/command/honk_horn'.format(self._vehicle_id))
+        return asyncio.get_event_loop().run_until_complete(super().honk_horn())
 
     def open_charge_port(self):
-        return self._api_client.post('vehicles/{}/command/charge_port_door_open'.format(self._vehicle_id))
+        return asyncio.get_event_loop().run_until_complete(super().open_charge_port())

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -1,30 +1,32 @@
-from .charge import Charge
-from .climate import Climate
-from .controls import Controls    
+import asyncio
+
+from .charge import Charge, ChargeSync
+from .climate import Climate, ClimateSync
+from .controls import Controls, ControlsSync
 
 class Vehicle:
     def __init__(self, api_client, vehicle):
         self._api_client = api_client
         self._vehicle = vehicle
 
-        self._charge = Charge(self._api_client, vehicle['id'])
-        self._climate = Climate(self._api_client, vehicle['id'])
-        self._controls = Controls(self._api_client, vehicle['id'])
+        self.charge = Charge(self._api_client, vehicle['id'])
+        self.climate = Climate(self._api_client, vehicle['id'])
+        self.controls = Controls(self._api_client, vehicle['id'])
 
-    def is_mobile_access_enabled(self):
-        return self._api_client.get('vehicles/{}/mobile_enabled'.format(self.id))
+    async def is_mobile_access_enabled(self):
+        return await self._api_client.get('vehicles/{}/mobile_enabled'.format(self.id))
 
-    def get_state(self):
-        return self._api_client.get('vehicles/{}/data_request/vehicle_state'.format(self.id))
+    async def get_state(self):
+        return await self._api_client.get('vehicles/{}/data_request/vehicle_state'.format(self.id))
 
-    def get_drive_state(self):
-        return self._api_client.get('vehicles/{}/data_request/drive_state'.format(self.id))
+    async def get_drive_state(self):
+        return await self._api_client.get('vehicles/{}/data_request/drive_state'.format(self.id))
 
-    def get_gui_settings(self):
-        return self._api_client.get('vehicles/{}/data_request/gui_settings'.format(self.id))
+    async def get_gui_settings(self):
+        return await self._api_client.get('vehicles/{}/data_request/gui_settings'.format(self.id))
 
-    def wake_up(self):
-        return self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+    async def wake_up(self):
+        return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
 
     @property
     def id(self):
@@ -42,14 +44,26 @@ class Vehicle:
     def state(self):
         return self._vehicle['state']
 
-    @property
-    def charge(self):
-        return self._charge
+class VehicleSync(Vehicle):
+    def __init__(self, api_client, vehicle):
+        self._api_client = api_client
+        self._vehicle = vehicle
 
-    @property
-    def climate(self):
-        return self._climate
+        self.charge = ChargeSync(self._api_client, vehicle['id'])
+        self.climate = ClimateSync(self._api_client, vehicle['id'])
+        self.controls = ControlsSync(self._api_client, vehicle['id'])
 
-    @property
-    def controls(self):
-        return self._controls
+    def is_mobile_access_enabled(self):
+        return asyncio.get_event_loop().run_until_complete(super().is_mobile_access_enabled())
+
+    def get_state(self):
+        return asyncio.get_event_loop().run_until_complete(super().get_state())
+
+    def get_drive_state(self):
+        return asyncio.get_event_loop().run_until_complete(super().get_drive_state())
+
+    def get_gui_settings(self):
+        return asyncio.get_event_loop().run_until_complete(super().get_gui_settings())
+
+    def wake_up(self):
+        return asyncio.get_event_loop().run_until_complete(super().wake_up())


### PR DESCRIPTION
-- Review after merging asyncio branch (this is built off that one) --

The login details are not needed once an API token has been generated. The client even appears to have code to automatically refresh the token.

By allowing the client to be restored from a previous token, we can remove the burden from applications to store the user's credentials securely. Therefore, I've made the token a public attribute, and added a parameter to initialise the client from a previously saved token.