### PR TITLE
Add update method to vehicle

### DIFF
--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -30,11 +30,9 @@ class Vehicle:
 
     async def wake_up(self):
         self._vehicle = await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
-        return self._vehicle
     
     async def update(self):      
         self._vehicle = await self._api_client.get('vehicles/{}'.format(self.id))
-        return self._vehicle
     
     @property
     def id(self):

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -3,7 +3,7 @@ import asyncio
 from .charge import Charge
 from .climate import Climate
 from .controls import Controls
-#tyddynonn 20200125 - add update()to refresh vehicle info, update internal state in wake_up()
+
 class Vehicle:
     def __init__(self, api_client, vehicle):
         self._api_client = api_client
@@ -29,11 +29,11 @@ class Vehicle:
         return await self._api_client.get('vehicles/{}/data_request/gui_settings'.format(self.id))
 
     async def wake_up(self):
-        self._vehicle= await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+        self._vehicle = await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
         return self._vehicle
     
     async def update(self):      
-        self._vehicle=await self._api_client.get('vehicles/{}'.format(self.id))
+        self._vehicle = await self._api_client.get('vehicles/{}'.format(self.id))
         return self._vehicle
     
     @property

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -3,7 +3,7 @@ import asyncio
 from .charge import Charge
 from .climate import Climate
 from .controls import Controls
-#tyddynonn 20200125 - add update method to refresh vehicle info
+#tyddynonn 20200125 - add update()to refresh vehicle info, update internal state in wake_up()
 class Vehicle:
     def __init__(self, api_client, vehicle):
         self._api_client = api_client
@@ -29,7 +29,8 @@ class Vehicle:
         return await self._api_client.get('vehicles/{}/data_request/gui_settings'.format(self.id))
 
     async def wake_up(self):
-        return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+        self._vehicle= await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+        return self._vehicle
     
     async def update(self):      
         self._vehicle=await self._api_client.get('vehicles/{}'.format(self.id))

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -3,7 +3,7 @@ import asyncio
 from .charge import Charge
 from .climate import Climate
 from .controls import Controls
-
+#tyddynonn 20200125 - add update method to refresh vehicle info
 class Vehicle:
     def __init__(self, api_client, vehicle):
         self._api_client = api_client
@@ -30,7 +30,11 @@ class Vehicle:
 
     async def wake_up(self):
         return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
-
+    
+    async def update(self):      
+        self._vehicle=await self._api_client.get('vehicles/{}'.format(self.id))
+        return self._vehicle
+    
     @property
     def id(self):
         return self._vehicle['id']


### PR DESCRIPTION
I find I often need to check whether the vehicle was awake before issuing other commands. 

So I added the update() method to Vehicle to refresh the saved state. The advantage is that this runs fairly quickly - I don't think the back end needs to call the car to do this. But wake_up() takes a while, and often needs to be retried.

Then I can write something like
async def wake_up(v):  
    state = await v.update()
    print ('In wake_up, state is ', v.state)
    if (v.state != 'online') :
        print('Waking car...')
        retrycount = 0          
        while retrycount < 3 :
            state = await v.wake_up()
            #print (state)
            if (state['state'] == 'online'):
                break
            time.sleep(5)
            retrycount +=1
            
        if (retrycount== 3) :
            raise ApiError('Cannot wake car')

Would probably be a good thing if the api call to wake_up() also refreshed the saved vehicle state.