### PR TITLE
Allow attribute access to all vehicle details returned from API.

### DIFF
--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -31,18 +31,13 @@ class Vehicle:
     async def wake_up(self):
         return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
 
-    @property
-    def id(self):
-        return self._vehicle['id']
+    def __dir__(self):
+        """Include _vehicle keys in dir(), which are accessible with __getattr__()."""
+        return super().__dir__() | self._vehicle.keys()
 
-    @property
-    def display_name(self):
-        return self._vehicle['display_name']
-
-    @property
-    def vin(self):
-        return self._vehicle['vin']
-
-    @property
-    def state(self):
-        return self._vehicle['state']
+    def __getattr__(self, name):
+        """Allow attribute access to _vehicle details."""
+        try:
+            return self._vehicle[name]
+        except KeyError:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")


### PR DESCRIPTION
This dynamically allows access to all vehicle attributes returned from the API.

dir() output is customised to ensure these attributes are discoverable.