### PR TITLE
1 - Wakeup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ async def main():
     for v in vehicles:
         print(v.vin)
         await v.controls.flash_lights()
-        
+
     await client.close()
 
 asyncio.run(main())
@@ -39,6 +39,8 @@ async def main():
     print("Backup reserve percent = %d" % (reserve))
     print("Increment backup reserve percent")
     await energy_sites[0].set_backup_reserve_percent(reserve+1)
+
+    await client.close()
 
 asyncio.run(main())
 ```

--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import aiohttp
 
-from .exceptions import ApiError, AuthenticationError
+from .exceptions import ApiError, AuthenticationError, VehicleUnavailableError
 from .vehicle import Vehicle
 from .energy import Energy
 
@@ -87,6 +87,8 @@ class TeslaApiClient:
             response_json = await resp.json()
 
         if 'error' in response_json:
+            if 'vehicle unavailable' in response_json['error']:
+                raise VehicleUnavailableError()
             raise ApiError(response_json['error'])
 
         return response_json['response']
@@ -99,6 +101,8 @@ class TeslaApiClient:
             response_json = await resp.json()
 
         if 'error' in response_json:
+            if 'vehicle unavailable' in response_json['error']:
+                raise VehicleUnavailableError()
             raise ApiError(response_json['error'])
 
         return response_json['response']

--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import aiohttp
 
+from .exceptions import ApiError, AuthenticationError
 from .vehicle import Vehicle
 from .energy import Energy
 
@@ -90,7 +91,7 @@ class TeslaApiClient:
 
         return response_json['response']
 
-    async def post(self, endpoint, data = {}):
+    async def post(self, endpoint, data=None):
         await self.authenticate()
         url = '{}/{}'.format(API_URL, endpoint)
 
@@ -107,11 +108,3 @@ class TeslaApiClient:
 
     async def list_energy_sites(self, _class=Energy):
         return [_class(self, products['energy_site_id']) for products in await self.get('products')]
-
-class AuthenticationError(Exception):
-    def __init__(self, error):
-        super().__init__('Authentication to the Tesla API failed: {}'.format(error))
-
-class ApiError(Exception):
-    def __init__(self, error):
-        super().__init__('Tesla API call failed: {}'.format(error))

--- a/tesla_api/charge.py
+++ b/tesla_api/charge.py
@@ -1,18 +1,18 @@
 import asyncio
 
 class Charge:
-    def __init__(self, api_client, vehicle_id):
-        self._api_client = api_client
-        self._vehicle_id = vehicle_id
+    def __init__(self, vehicle):
+        self._vehicle = vehicle
+        self._api_client = vehicle._api_client
 
     async def get_state(self):
-        return await self._api_client.get('vehicles/{}/data_request/charge_state'.format(self._vehicle_id))
+        return await self._api_client.get('vehicles/{}/data_request/charge_state'.format(self._vehicle.id))
 
     async def start_charging(self):
-        return await self._api_client.post('vehicles/{}/command/charge_start'.format(self._vehicle_id))
+        return await self._vehicle._command('charge_start')
 
     async def stop_charging(self):
-        return await self._api_client.post('vehicles/{}/command/charge_stop'.format(self._vehicle_id))
+        return await self._vehicle._command('charge_stop')
 
     async def set_charge_limit(self, percentage):
         percentage = round(percentage)
@@ -20,7 +20,4 @@ class Charge:
         if not (50 <= percentage <= 100):
             raise ValueError('Percentage should be between 50 and 100')
 
-        return await self._api_client.post(
-            'vehicles/{}/command/set_charge_limit'.format(self._vehicle_id),
-            {'percent': percentage}
-        )
+        return await self._vehicle._command('set_charge_limit', {'percent': percentage})

--- a/tesla_api/climate.py
+++ b/tesla_api/climate.py
@@ -1,25 +1,24 @@
 import asyncio
+from functools import partialmethod
 
 class Climate:
-    def __init__(self, api_client, vehicle_id):
-        self._api_client = api_client
-        self._vehicle_id = vehicle_id
+    def __init__(self, vehicle):
+        self._vehicle = vehicle
+        self._api_client = vehicle._api_client
 
     async def get_state(self):
-        return await self._api_client.get('vehicles/{}/data_request/climate_state'.format(self._vehicle_id))
+        return await self._api_client.get('vehicles/{}/data_request/climate_state'.format(self._vehicle.id))
 
     async def start_climate(self):
-        return await self._api_client.post('vehicles/{}/command/auto_conditioning_start'.format(self._vehicle_id))
+        return await self._vehicle._command('auto_conditioning_start')
 
     async def stop_climate(self):
-        return await self._api_client.post('vehicles/{}/command/auto_conditioning_stop'.format(self._vehicle_id))
+        return await self._vehicle._command('auto_conditioning_stop')
 
     async def set_temperature(self, driver_temperature, passenger_temperature=None):
-        return await self._api_client.post(
-            'vehicles/{}/command/set_temps'.format(self._vehicle_id),
-            {'driver_temp': driver_temperature,
-             'passenger_temp': passenger_temperature or driver_temperature}
-        )
+        data = {'driver_temp': driver_temperature,
+                'passenger_temp': passenger_temperature or driver_temperature}
+        return await self._vehicle._command('set_temps', data)
     
     async def set_seat_heater(self, temp=0, seat=0):
         # temp = The desired level for the heater. (0-3)
@@ -29,10 +28,10 @@ class Climate:
         # 2 - Rear left
         # 4 - Rear center
         # 5 - Rear right
-        return await self._api_client.post('vehicles/{}/command/remote_seat_heater_request'.format(self._vehicle_id),{'heater':seat,'level':temp})
+        return await self._vehicle._command('remote_seat_heater_request',
+                                            {'heater': seat, 'level': temp})
 
-    async def start_steering_wheel_heater(self):
-        return await self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':True})
-
-    async def stop_steering_wheel_heater(self):
-        return await self._api_client.post('vehicles/{}/command/remote_steering_wheel_heater_request'.format(self._vehicle_id),{'on':False})
+    async def steering_wheel_heater(self, on: bool):
+        return await self._vehicle._command('remote_steering_wheel_heater_request', {'on': on})
+    start_steering_wheel_heater = partialmethod(steering_wheel_heater, True)
+    stop_steering_wheel_heater = partialmethod(steering_wheel_heater, False)

--- a/tesla_api/controls.py
+++ b/tesla_api/controls.py
@@ -1,30 +1,30 @@
 import asyncio
+from functools import partialmethod
 
 STATE_VENT = 'vent'
 STATE_CLOSE = 'close'
 
 class Controls:
-    def __init__(self, api_client, vehicle_id):
-        self._api_client = api_client
-        self._vehicle_id = vehicle_id
+    def __init__(self, vehicle):
+        self._vehicle = vehicle
+        self._api_client = vehicle._api_client
 
     async def _set_sunroof_state(self, state):
-        return await self._api_client.post(
-            'vehicles/{}/command/sun_roof_control'.format(self._vehicle_id),
-            {'state': state}
-        )
-
-    async def vent_sunroof(self):
-        return await self._set_sunroof_state(STATE_VENT)
-
-    async def close_sunroof(self):
-        return await self._set_sunroof_state(STATE_CLOSE)
+        return await self._vehicle._command('sun_roof_control', {'state': state})
+    vent_sunroof = partialmethod(_set_sunroof_state, STATE_VENT)
+    close_sunroof = partialmethod(_set_sunroof_state, STATE_CLOSE)
 
     async def flash_lights(self):
-        return await self._api_client.post('vehicles/{}/command/flash_lights'.format(self._vehicle_id))
+        return await self._vehicle._command('flash_lights')
 
     async def honk_horn(self):
-        return await self._api_client.post('vehicles/{}/command/honk_horn'.format(self._vehicle_id))
+        return await self._vehicle._command('honk_horn')
 
     async def open_charge_port(self):
-        return await self._api_client.post('vehicles/{}/command/charge_port_door_open'.format(self._vehicle_id))
+        return await self._vehicle._command('charge_port_door_open')
+
+    async def door_lock(self):
+        return await self._vehicle._command('door_lock')
+
+    async def door_unlock(self):
+        return await self._vehicle._command('door_unlock')

--- a/tesla_api/exceptions.py
+++ b/tesla_api/exceptions.py
@@ -1,0 +1,8 @@
+class AuthenticationError(Exception):
+    def __init__(self, error):
+        super().__init__('Authentication to the Tesla API failed: {}'.format(error))
+
+class ApiError(Exception):
+    def __init__(self, error):
+        super().__init__('Tesla API call failed: {}'.format(error))
+        self.reason = error

--- a/tesla_api/exceptions.py
+++ b/tesla_api/exceptions.py
@@ -6,3 +6,7 @@ class ApiError(Exception):
     def __init__(self, error):
         super().__init__('Tesla API call failed: {}'.format(error))
         self.reason = error
+
+class VehicleUnavailableError(Exception):
+    def __init__(self):
+        super().__init__('Vehicle failed to wake up.')

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -31,9 +31,9 @@ class Vehicle:
         endpoint = 'vehicles/{}/command/{}'.format(self.id, command_endpoint)
         try:
             res = await self._api_client.post(endpoint, data)
-        except ApiError as e:
+        except VehicleUnavailableError as e:
             # If first attempt, retry with a wake up.
-            if 'vehicle unavailable' in e.reason and _retry:
+            if _retry:
                 self._vehicle['state'] = 'offline'
                 return await self._command(command_endpoint, data, _retry=False)
             raise

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -45,10 +45,13 @@ class Vehicle:
         return await self._api_client.get('vehicles/{}/data_request/gui_settings'.format(self.id))
 
     async def wake_up(self):
-        return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+        self._vehicle = await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
 
     async def remote_start(self):
         return await self._command('remote_start_drive')
+    
+    async def update(self):      
+        self._vehicle = await self._api_client.get('vehicles/{}'.format(self.id))
 
     def __dir__(self):
         """Include _vehicle keys in dir(), which are accessible with __getattr__()."""

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -73,8 +73,12 @@ class Vehicle:
         except asyncio.TimeoutError:
             raise VehicleUnavailableError()
 
-    async def remote_start(self):
-        return await self._command('remote_start_drive')
+    async def remote_start(self, password):
+        """Enable keyless driving (must start car within a 2 minute window).
+
+        password - The account password to reauthenticate.
+        """
+        return await self._command('remote_start_drive', data={'password': password})
     
     async def update(self):      
         self._vehicle = await self._api_client.get('vehicles/{}'.format(self.id))

--- a/tesla_api/vehicle.py
+++ b/tesla_api/vehicle.py
@@ -3,15 +3,31 @@ import asyncio
 from .charge import Charge
 from .climate import Climate
 from .controls import Controls
+from .exceptions import ApiError
 
 class Vehicle:
     def __init__(self, api_client, vehicle):
         self._api_client = api_client
         self._vehicle = vehicle
 
-        self.charge = Charge(self._api_client, vehicle['id'])
-        self.climate = Climate(self._api_client, vehicle['id'])
-        self.controls = Controls(self._api_client, vehicle['id'])
+        self.charge = Charge(self)
+        self.climate = Climate(self)
+        self.controls = Controls(self)
+
+    async def _command(self, command_endpoint, data=None):
+        """Handles vehicle commands with the common reason/result response.
+
+        Args:
+            command_endpoint: The final part of the endpoint (after /command/).
+            data: Optional JSON data to send with the request.
+
+        Raises:
+            ApiError on unsuccessful response.
+        """
+        endpoint = 'vehicles/{}/command/{}'.format(self.id, command_endpoint)
+        res = await self._api_client.post(endpoint, data)
+        if res.get('result') is not True:
+            raise ApiError(res.get('reason', ''))
 
     async def is_mobile_access_enabled(self):
         return await self._api_client.get('vehicles/{}/mobile_enabled'.format(self.id))
@@ -30,6 +46,9 @@ class Vehicle:
 
     async def wake_up(self):
         return await self._api_client.post('vehicles/{}/wake_up'.format(self.id))
+
+    async def remote_start(self):
+        return await self._command('remote_start_drive')
 
     def __dir__(self):
         """Include _vehicle keys in dir(), which are accessible with __getattr__()."""


### PR DESCRIPTION
This removes the burden of needing to figure out the wake_up API logic, by automatically retrying the call until the car is awake.

i.e. After `await v.wake_up()` the developer can assume the car is awake.

We also implicitly try waking the car when initiating a command. I don't see any reason someone would not want to wake the car when explicitly asking it do perform an action. Other endpoints remain without the wakeup logic, as it may not be desirable to wake the car when just retrieving data.

This also introduces the `VehicleUnavailableError` exception, which developers can use to handle the case when the vehicle is unavailable (as opposed to other API errors).