### PR TITLE
Added token property and filtered the list_ methods

### DIFF
--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -88,15 +88,11 @@ class TeslaApiClient:
             'Authorization': 'Bearer {}'.format(self._token['access_token'])
         }
 
-    async def get(self, endpoint, query=None):
+    async def get(self, endpoint, params=None):
         await self.authenticate()
         url = '{}/{}'.format(API_URL, endpoint)
-        if query is not None:
-            url += f'?{query}'
-
-        async with self._session.get(url, headers=self._get_headers()) as resp:
+        async with self._session.get(url, headers=self._get_headers(), params=params) as resp:
             response_json = await resp.json()
-
         if 'error' in response_json:
             if 'vehicle unavailable' in response_json['error']:
                 raise VehicleUnavailableError()
@@ -118,7 +114,7 @@ class TeslaApiClient:
         return response_json['response']
 
     async def list_vehicles(self, _class=Vehicle):
-        return [_class(self, vehicle) for product in await self.get('vehicles') if 'vehicle_id' in product]
+        return [_class(self, vehicle) for product in await self.get('vehicles')]
 
     async def list_energy_sites(self, _class=Energy):
         return [_class(self, product['energy_site_id']) for product in await self.get('products') if 'energy_site_id' in product]

--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -38,6 +38,16 @@ class TeslaApiClient:
         self._new_token_callback = on_new_token
         self._session = aiohttp.ClientSession()
 
+    @property
+    def token(self):
+        """
+        The authentication token in JSON string format
+
+        Contains expiration data and a refresh token, an must be presented in full to the constructor
+        as an alternative to email/password authentication
+        """
+        return json.dumps(self._token)
+
     async def close(self):
         await self._session.close()
 
@@ -111,7 +121,9 @@ class TeslaApiClient:
         return response_json['response']
 
     async def list_vehicles(self, _class=Vehicle):
-        return [_class(self, vehicle) for vehicle in await self.get('vehicles')]
+        return [_class(self, vehicle) for product in await self.get('vehicles') if 'vehicle_id' in product]
 
     async def list_energy_sites(self, _class=Energy):
-        return [_class(self, products['energy_site_id']) for products in await self.get('products')]
+        return [_class(self, product['energy_site_id']) for product in await self.get('products') if 'energy_site_id' in product]
+
+

--- a/tesla_api/energy.py
+++ b/tesla_api/energy.py
@@ -23,7 +23,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import asyncio
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -79,7 +78,7 @@ class Energy:
         """
         params = {'kind': kind, 'period': period}
         if end_date is not None:
-            if type(end_date) is datetime:
+            if isinstance(end_date, datetime):
                 if end_date.hour == 0:
                     # if the datetime object's time is 00:00 then the API returns nothing. We adjust by adding an hour
                     # so you can use datetime(year=2020, month=5, day=2) and it gets the data for May 2, 2020 as expected
@@ -87,10 +86,11 @@ class Energy:
                 if end_date.tzinfo is None and time_zone is not None:
                     tz = pytz.timezone(time_zone)
                     end_date = tz.localize(end_date, time_zone)
-            params['end_date'] = end_date.isoformat() if type(end_date) is datetime else end_date
+            params['end_date'] = end_date.isoformat() if isinstance(end_date, datetime) else end_date
         if time_zone is not None:
             params['time_zone'] = time_zone
-        return await self._api_client.get('energy_sites/{}/calendar_history'.format(self._energy_site_id), params=params)
+        return await self._api_client.get('energy_sites/{}/calendar_history'.format(self._energy_site_id),
+                                          params=params)
 
     # Helper functions for get_energy_site_live_status
     async def get_energy_site_live_status_percentage_charged(self):

--- a/tesla_api/energy.py
+++ b/tesla_api/energy.py
@@ -26,8 +26,6 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
-import pytz
-
 
 class Energy:
     def __init__(self, api_client, energy_site_id):
@@ -62,33 +60,26 @@ class Energy:
         return await self._api_client.get('energy_sites/{}/live_status'.format(self._energy_site_id))
 
     async def get_energy_site_calendar_history_data(self, kind: str = 'energy', period: str = 'day',
-                                                    end_date: [str, datetime] = None,
-                                                    time_zone: str = None) -> Optional[dict]:
+                                                    end_date: [str, datetime] = None) -> Optional[dict]:
         """
         Returns historical energy data
         :param kind: [power, energy, self_consumption]
         :param period: Amount of time to include in report. One of day, week, month, year, and lifetime.
                     When kind is 'power', this parameter is ignored, and the period is always 'day'
-        :param end_date: ISO 8601 datetime, e.g. 2019-12-23T17:39:18.546Z. either in str or as datetime
-                    The response report interval ends on this datetime and starts at the beginning of the given period
-                    at 1:00 AM.  Note time cannot be 00:00. Defaults to the current time.
-        :param time_zone: IANA/Olsen time zone identifier, e.g. America/New_York. If set, and if the end_date is a
-                    'naive' datetime object (without timezone info) this field will be used to set the timezone
-                    for the end_date.  Otherwise it is ignored
+        :param end_date: ISO 8601 datetime, e.g. 2019-12-23T17:39:18.546Z. either in str or as timezone aware datetime.
+                    The response report interval ends on this datetime and starts at the beginning of the given period.
+                    Note time cannot be 00:00, so if the datetime object has no hour and minute, it will be set to 23:59. 
+                    This allows you to call with datetime(year=2020, month=5, day=1) and get all data for May 1st.
+                    Defaults to the current time.
         """
         params = {'kind': kind, 'period': period}
         if end_date is not None:
             if isinstance(end_date, datetime):
-                if end_date.hour == 0:
-                    # if the datetime object's time is 00:00 then the API returns nothing. We adjust by adding an hour
+                if end_date.hour == 0 and end_date.minute == 0:
+                    # if the datetime object's time is 00:00 then the API returns nothing. We adjust by adding 23:59
                     # so you can use datetime(year=2020, month=5, day=2) and it gets the data for May 2, 2020 as expected
-                    end_date = end_date + timedelta(hours=1)
-                if end_date.tzinfo is None and time_zone is not None:
-                    tz = pytz.timezone(time_zone)
-                    end_date = tz.localize(end_date, time_zone)
+                    end_date = end_date + timedelta(hours=23, minutes=59)
             params['end_date'] = end_date.isoformat() if isinstance(end_date, datetime) else end_date
-        if time_zone is not None:
-            params['time_zone'] = time_zone
         return await self._api_client.get('energy_sites/{}/calendar_history'.format(self._energy_site_id),
                                           params=params)
 


### PR DESCRIPTION
The token property allows calling client.token and storing that token when the client is created again
in the future (without the need for email/password)

Filtering the list_vehicles and list_energy_sites is required if a user has both a vehicle and an energy
site.  The original implementation throws an error in that case