### PR TITLE
Add v3 token refresh + v2 long-lived token generation (optional)

### DIFF
--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -22,7 +22,7 @@ class TeslaApiClient:
     callback_wake_up = None  # Called when attempting to wake a vehicle.
     timeout = 30  # Default timeout for operations such as Vehicle.wake_up().
 
-    def __init__(self, email=None, password=None, code=None, token=None, on_new_token=None, on_new_toke_args=None):
+    def __init__(self, email=None, password=None, code=None, token=None, on_new_token=None, on_new_toke_args=None, timeout_seconds=60):
         """Creates client from provided credentials.
 
         Email and Password logins (with MFA support) require client side javascript
@@ -54,7 +54,8 @@ class TeslaApiClient:
         self._code = json.loads(code) if code else None
         self._token = json.loads(token) if token else None
         self._new_token_callback = on_new_token
-        self._session = aiohttp.ClientSession()
+        session_timeout = aiohttp.ClientTimeout(total=None,sock_connect=timeout_seconds, sock_read=timeout_seconds)
+        self._session = aiohttp.ClientSession(timeout=session_timeout)
 
     async def __aenter__(self):
         return self

--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 from datetime import datetime, timedelta
 
@@ -9,10 +10,12 @@ from .exceptions import ApiError, AuthenticationError, VehicleUnavailableError
 from .vehicle import Vehicle
 
 TESLA_API_BASE_URL = "https://owner-api.teslamotors.com/"
-TOKEN_URL = TESLA_API_BASE_URL + "oauth/token"
+V2TOKEN_URL = TESLA_API_BASE_URL + "oauth/token"
+V3TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
 API_URL = TESLA_API_BASE_URL + "api/1"
 
-OAUTH_CLIENT_ID = "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384"
+V3OAUTH_CLIENT_ID = "ownerapi"
+V2OAUTH_CLIENT_ID = "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384"
 OAUTH_CLIENT_SECRET = "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3"
 
 
@@ -21,20 +24,34 @@ class TeslaApiClient:
     callback_wake_up = None  # Called when attempting to wake a vehicle.
     timeout = 30  # Default timeout for operations such as Vehicle.wake_up().
 
-    def __init__(self, email=None, password=None, token=None, on_new_token=None):
+    def __init__(self, email=None, password=None, code=None, token=None, short_lived_v3token=True, on_new_token=None):
         """Creates client from provided credentials.
 
+        Email and Password logins (with MFA support) require client side javascript
+        to generate a one time code which can be used to create oauth tokens.
+        For more information see:
+        https://tesla-api.timdorr.com/api-basics/authentication#step-2-obtain-an-authorization-code
+        and use the 'code' option to use this module.
+
         If token is not provided, or is no longer valid, then a new token will
-        be fetched if email and password are provided.
+        be fetched if a code (obtained from the tesla auth webpage) is available.
+        code consist of the itself + a code_verifier, e.g
+        code = {'code': 'codedata', 'code_verifier': 'verification data'}
+
+        Per default we use short lived access tokens which need refreshing every
+        300 seconds. For long running sessions it is possible to use 'old v3 style'
+        access tokens. For this set short_lived_v3token to False
 
         If on_new_token is provided, it will be called with the newly created token.
         This should be used to save the token, both after initial login and after an
         automatic token renewal. The token is returned as a string and can be passed
         directly into this constructor.
         """
-        assert token is not None or (email is not None and password is not None)
-        self._email = email
-        self._password = password
+        if email or password:
+            raise Exception("Email and Password logins currently not supported")
+        assert token is not None or code is not None
+        self._short_lived_v3token = short_lived_v3token
+        self._code = json.loads(code) if code else None
         self._token = json.loads(token) if token else None
         self._new_token_callback = on_new_token
         self._session = aiohttp.ClientSession()
@@ -48,41 +65,64 @@ class TeslaApiClient:
     async def close(self):
         await self._session.close()
 
-    async def _get_token(self, data):
+    def decode_jwt_token(self, jwt_token):
+        headers_enc, payload_enc, verify_signature = jwt_token.split('.')
+        payload_enc += '=' * (-len(payload_enc) % 4)  # add padding
+        payload = json.loads(base64.b64decode(payload_enc).decode("utf-8"))
+        return payload
+
+    async def _get_token(self, url, data, headers={}):
         request_data = {
-            "client_id": OAUTH_CLIENT_ID,
             "client_secret": OAUTH_CLIENT_SECRET,
         }
         request_data.update(data)
 
-        async with self._session.post(TOKEN_URL, data=request_data) as resp:
+        async with self._session.post(url, data=request_data, headers=headers) as resp:
             response_json = await resp.json()
             if resp.status == 401:
                 raise AuthenticationError(response_json)
-
-        # Send token to application via callback.
-        if self._new_token_callback:
-            asyncio.create_task(self._new_token_callback(json.dumps(response_json)))
-
+        if "error" in response_json:
+            raise AuthenticationError(response_json)
         return response_json
 
-    async def _get_new_token(self):
-        data = {"grant_type": "password", "email": self._email, "password": self._password}
-        return await self._get_token(data)
+    async def _get_new_token_with_code(self):
+        request_data = {"grant_type": "authorization_code", "client_id": V3OAUTH_CLIENT_ID,
+            "code": self._code["code"], "code_verifier": self._code["code_verifier"],
+            "redirect_uri": "https://auth.tesla.com/void/callback",
+        }
+        return await self._get_token(V3TOKEN_URL, request_data)
 
     async def _refresh_token(self, refresh_token):
-        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
-        return await self._get_token(data)
+        request_data = {"grant_type": "refresh_token", "refresh_token": refresh_token, "client_id": V3OAUTH_CLIENT_ID, "scope": "openid email offline_access"}
+        v3_token_data = await self._get_token(V3TOKEN_URL, request_data)
+        if self._short_lived_v3token:
+            return v3_token_data
+        request_data = {"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer", "client_id": V2OAUTH_CLIENT_ID}
+        print(v3_token_data)
+        return await self._get_token(V2TOKEN_URL, request_data, headers = {"Authorization": "Bearer {}".format(v3_token_data["access_token"])})
 
     async def authenticate(self):
         if not self._token:
-            self._token = await self._get_new_token()
+            self._token = await self._get_new_token_with_code()
 
-        expiry_time = timedelta(seconds=self._token["expires_in"])
-        expiration_date = datetime.fromtimestamp(self._token["created_at"]) + expiry_time
+        if "expires_at" not in self._token:
+            jwt_data = self.decode_jwt_token(self._token["access_token"])
+            self._token["expires_at"] = jwt_data["exp"]
+        expiration_date = datetime.fromtimestamp(self._token["expires_at"])
 
         if datetime.utcnow() >= expiration_date:
-            self._token = await self._refresh_token(self._token["refresh_token"])
+            token_data = await self._refresh_token(self._token["refresh_token"])
+            # We need to distinguish between new v3 and old v2 style tokens here.
+            # v2 refresh tokens CAN NOT be used anymore for refresh they return an error in the Tesla API backend
+            if self._short_lived_v3token:
+                self._token = token_data
+            else:
+                self._token["access_token"] = token_data["access_token"]
+                self._token["expires_at"] = token_data["created_at"] + token_data["expires_in"]
+
+            # Send token to application via callback.
+            if self._new_token_callback:
+                asyncio.create_task(self._new_token_callback(json.dumps(self._token)))
 
     def _get_headers(self):
         return {"Authorization": "Bearer {}".format(self._token["access_token"])}

--- a/tesla_api/charge.py
+++ b/tesla_api/charge.py
@@ -20,3 +20,9 @@ class Charge:
             raise ValueError("Percentage should be between 50 and 100")
 
         return await self._vehicle._command("set_charge_limit", {"percent": percentage})
+
+    async def set_charging_amps(self, amperage):
+        if not (5 <= amperage <= 40):
+            raise ValueError("Amerage should be between 5 and 40")
+
+        return await self._vehicle._command("set_charging_amps", {"charging_amps": amperage})

--- a/tesla_api/exceptions.py
+++ b/tesla_api/exceptions.py
@@ -12,3 +12,8 @@ class ApiError(Exception):
 class VehicleUnavailableError(Exception):
     def __init__(self):
         super().__init__("Vehicle failed to wake up.")
+
+
+class JWTDecodeError(Exception):
+    def __init__(self):
+        super().__init__("Unable to decode JWT")


### PR DESCRIPTION
In the light of https://github.com/timdorr/tesla-api/issues/260 (former ticket https://github.com/timdorr/tesla-api/issues/215) and issue #31 I created this patch which deprecates email/password logins for now and introduces Tesla's oauth V3 token handling including very short-lived 'code' based tokens.
More but not very precise information can be found here: https://tesla-api.timdorr.com/api-basics/authentication#step-2-obtain-an-authorization-code

V3 access tokens are only valid for 300 seconds which is not suitable for most server applications, although they get renewed automatically I an added the option **_short_lived_v3token_** which can be set to False (default True) in order to created a 'old' V2 token which is valid for the usual 45 days.
